### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -42,7 +42,7 @@
     
   ],
 
-  "license": "Artistic 2.0",
+  "license": "Artistic-2.0",
 
   "test-depends": [
     


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license